### PR TITLE
add templateReader options for custom template rendering

### DIFF
--- a/lib/AutoWebPlugin.js
+++ b/lib/AutoWebPlugin.js
@@ -145,12 +145,12 @@ class AutoWebPlugin {
 
 			// add an WebPlugin for every page to output an html
 			const { templatePath } = entryMap[entryName];
-			new WebPlugin({
+			new WebPlugin(Object.assign({}, this.options, {
 				template: templatePath,
 				filename: `${entryName}.html`,
 				requires: useCommonsChunk ? [commonsChunk.name, entryName] : [entryName],
 				stylePublicPath,
-			}).apply(compiler);
+			})).apply(compiler);
 		});
 
 		if (useCommonsChunk) {

--- a/lib/HTMLDocument.js
+++ b/lib/HTMLDocument.js
@@ -73,7 +73,8 @@ class HTMLDocument {
 		let htmlString = DefaultHtmlTemplate;
 		const { template: htmlTemplateFilePath} = options;
 		if (typeof htmlTemplateFilePath === 'string') {
-			htmlString = fs.readFileSync(htmlTemplateFilePath, {
+			const templateReader = options.templateReader || fs.readFileSync
+			htmlString = templateReader(htmlTemplateFilePath, {
 				encoding: 'utf8'
 			});
 		}


### PR DESCRIPTION
可以在 webpack 内自定义模板渲染规则 

```
    new AutoWebPlugin('./src/pages/', {
      template: (pageName) => {
        let templatePath = path.resolve('./src/pages/', pageName, 'index.html');
        if (fs.existsSync(templatePath)) {
          return templatePath;
        }
        return './src/assets/template.html';
      },
      templateReader(templatePath) {
        const res = nunjucks.render(templatePath, {});
        return res;
      },
      ignorePages,
    }),

```