### PR TITLE
htmlOutputFilename was never used

### DIFF
--- a/lib/AutoWebPlugin.js
+++ b/lib/AutoWebPlugin.js
@@ -112,7 +112,7 @@ class AutoWebPlugin {
 			if (typeof filename === 'function') {
 				htmlOutputFilename = filename(pageName);
 			} else {
-				htmlOutputFilename = pageName;
+				htmlOutputFilename = `${pageName}.html`;
 			}
 
 			this.entryMap[pageName] = {
@@ -149,12 +149,12 @@ class AutoWebPlugin {
 			compilerOptions.entry = Object.assign(this.webpackEntry, compilerOptions.entry);
 
 			// add an WebPlugin for every page to output an html
-			const { templatePath, templateCompiler } = entryMap[pageName];
+			const { templatePath, templateCompiler, htmlOutputFilename } = entryMap[pageName];
 			new WebPlugin({
 				template: templatePath,
 				templateCompiler,
 				pageName,
-				filename: `${pageName}.html`,
+				filename: htmlOutputFilename,
 				requires: useCommonsChunk ? [commonsChunk.name, pageName] : [pageName],
 				stylePublicPath,
 				htmlMinify,


### PR DESCRIPTION
There was problem, when using filename option in AutoWebPlugin there were no option manupilate output path. 