### PR TITLE
Fix of cutting email links

### DIFF
--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -289,7 +289,8 @@ class Resource {
 					// 提前过滤调部分 URL 地址，提高性能，例如 http://url.cn/1.js  //url.cn/1.js  data:image/png;base64,iVBORw0K
 					if (
 						this.chunkName &&
-						!/(https?|data|:)?\/\/.+\..+.*/.test(this.chunkName)
+						!/(https?|data|:)?\/\/.+\..+.*/.test(this.chunkName) &&
+						!/mailto:.*@.*/.test(this.chunkName)
 					) {
 						// 相对于模版文件去解析资源文件地址
 						const filePath = path.resolve(


### PR DESCRIPTION
Currently by default web-webpack-plugin cutting off any email links.
For example, something like:
```<a href="mailto:test@test.com">test@test.com</a>```
I suggest resolving this issue by this PR.