### PR TITLE
fix: tapable包冲突问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
 	"dependencies": {
 		"file-type": "^8.1.0",
 		"parse5": "^5.0.0",
-		"webpack": "^4.16.0"
+		"webpack": "^4.16.0",
+		"tapable": "^1.1.0"
 	},
 	"devDependencies": {
 		"@types/react": "^16.4.7",


### PR DESCRIPTION
虽然webpack中有依赖tapable包，项目的node_modules有tapable，但是如果有个其他npm包声明了一个低版本的tapable，项目的node_modules就会是这个低版本的tapable包。比如项目package.json里面"eslint-import-resolver-webpack": "^0.11.1"，node_modules里的tapable包版本就是0.1.10。
就会产生报错：
```
TypeError: SyncWaterfallHook is not a constructor
    at WebPlugin.apply (E:\xxxxxx\node_modules\web-webpack-plugin\lib\WebPlugin.js:99:44)
```